### PR TITLE
Fixed DeprecationWarning about deep requiring uuidv4

### DIFF
--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -1,7 +1,7 @@
 const now = require('performance-now');
 const isBoolean = require('lodash.isboolean');
 const isEmpty = require('lodash.isempty');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const format = require('string-template');
 
 const STATES = {


### PR DESCRIPTION
Hey, great work with the library!

While using it in a project, I noticed this `DeprecationWarning` being spit out.

> DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.

On running node with the `--trace-deprecation` flag, it showed the warning originating from `node_modules/statman-stopwatch/lib/Stopwatch.js:24:16`

```js
if (isEmpty(name)) {
    name = uuid(); // <- Line 24
}
```

Creating this PR to update the import for `uuid` to fix the warning.

Cheers!


