### PR TITLE
modify read to returnb null vs NaN

### DIFF
--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -157,7 +157,7 @@ Stopwatch.prototype.toString = function () {
     let name = self.name();
     let state = self.state();
     let value = self.read();
-    if (value) value=value.toFixed(2);
+    if (value) {value=value.toFixed(2)};
     let output = `[${name} => state:${state}; value:${value}]`;
     return output;
 };

--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -128,7 +128,7 @@ Stopwatch.prototype.splitTime = function () {
 Stopwatch.prototype.read = Stopwatch.prototype.time = function (precision) {
     const self = this;
     const startTime = self.startTime;
-    let delta;
+    let delta=null;
 
     if (startTime) {
         let nowTime;
@@ -147,8 +147,6 @@ Stopwatch.prototype.read = Stopwatch.prototype.time = function (precision) {
         if (precision || precision === 0) {
             delta = delta.toFixed(precision);
         }
-    } else {
-        delta = NaN;
     }
 
     return delta;
@@ -158,7 +156,8 @@ Stopwatch.prototype.toString = function () {
     const self = this;
     let name = self.name();
     let state = self.state();
-    let value = self.read().toFixed(2);
+    let value = self.read()
+    if (value) value=value.toFixed(2);
     let output = `[${name} => state:${state}; value:${value}]`;
     return output;
 };

--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -156,7 +156,7 @@ Stopwatch.prototype.toString = function () {
     const self = this;
     let name = self.name();
     let state = self.state();
-    let value = self.read()
+    let value = self.read();
     if (value) value=value.toFixed(2);
     let output = `[${name} => state:${state}; value:${value}]`;
     return output;

--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -51,7 +51,7 @@ Stopwatch.prototype.start = function () {
 
     self._state = STATES.RUNNING;
     self.startTime = now();
-    self.stopTime=0;
+    self.stopTime = 0;
 };
 
 Stopwatch.prototype.stop = function () {
@@ -128,7 +128,7 @@ Stopwatch.prototype.splitTime = function () {
 Stopwatch.prototype.read = Stopwatch.prototype.time = function (precision) {
     const self = this;
     const startTime = self.startTime;
-    let delta=null;
+    let delta = null;
 
     if (startTime) {
         let nowTime;
@@ -157,7 +157,7 @@ Stopwatch.prototype.toString = function () {
     let name = self.name();
     let state = self.state();
     let value = self.read();
-    if (value) {value=value.toFixed(2)};
+    if (value) { value = value.toFixed(2) };
     let output = `[${name} => state:${state}; value:${value}]`;
     return output;
 };

--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -157,7 +157,7 @@ Stopwatch.prototype.toString = function () {
     let name = self.name();
     let state = self.state();
     let value = self.read();
-    if (value) { value = value.toFixed(2) };
+    if (value) { value = value.toFixed(2); }
     let output = `[${name} => state:${state}; value:${value}]`;
     return output;
 };

--- a/test/stopwatch-test.js
+++ b/test/stopwatch-test.js
@@ -15,6 +15,10 @@ function verifyDelta(expected, actual, acceptedconstiance) {
     assert.ok((actual >= lowerThreshold) && (actual <= upperThreshold), message);
 }
 
+function verifyIsNull(value) {
+    (value === null).should.be.true;
+}
+
 describe("stopwatch", function () {
     this.timeout(5000);
 
@@ -95,7 +99,7 @@ describe("stopwatch", function () {
 
         const stopwatch = new Stopwatch(false);
         setTimeout(function () {
-            stopwatch.read().should.be.NaN();
+            verifyIsNull(stopwatch.read());
             done();
         }, testtime);
     });
@@ -152,14 +156,14 @@ describe("stopwatch", function () {
 
     it("performing read without start() or stop() returns NaN", function (done) {
         const stopwatch = new Stopwatch();
-        assert.ok(isNaN(stopwatch.read()));
+        verifyIsNull(stopwatch.read());
         done();
     });
 
     it("performing read without start() returns NaN", function (done) {
         const stopwatch = new Stopwatch();
         stopwatch.stop();
-        assert.ok(isNaN(stopwatch.read()));
+        verifyIsNull(stopwatch.read());
         done();
     });
 
@@ -246,7 +250,7 @@ describe("stopwatch", function () {
             const stopwatch = new Stopwatch(false);
             stopwatch.setStartTimeDelta(initialStartTimeDelta);
             setTimeout(function () {
-                stopwatch.read().should.be.NaN();
+                verifyIsNull(stopwatch.read());
                 done();
             }, testtime);
         });


### PR DESCRIPTION
A non-started stopwatch.read() should return null rather than NaN